### PR TITLE
ci: use common docker reusable workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,6 @@
 name: Docker
 
+
 on:
   push:
     branches:
@@ -7,47 +8,20 @@ on:
       - master
     tags:
       - 'v*.*.*'
+    paths-ignore:
+      - '**/*.md'
+      - '.gitignore'
+      - '.github/**'
+      - '!.github/workflows/docker.yml'
+  workflow_dispatch:
 
-    workflow_dispatch:
-
-env:
-  DOCKER_FILE: docker/deluge.Dockerfile
-  DOCKER_REPO: codexstorage/deluge
 
 jobs:
-  docker:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-tags: true
-          fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Setup Docker Metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_REPO }}
-          flavor: |
-            latest=true
-          tags: |
-            type=sha
-
-      - name: Build and Push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ env.DOCKER_FILE }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  build-and-push:
+    name: Build and Push
+    uses: codex-storage/github-actions/.github/workflows/docker-reusable.yml@master
+    with:
+      docker_file: docker/deluge.Dockerfile
+      dockerhub_repo: codexstorage/deluge
+      tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
+    secrets: inherit


### PR DESCRIPTION
This is mostly an organizational change and we've switched to the a common [Docker - Reusable](https://github.com/codex-storage/github-actions/tree/master#docker---reusable) workflow.