### PR TITLE
docker: adjust dockerfile and workflow for arm64 builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,4 +24,6 @@ jobs:
       docker_file: docker/deluge.Dockerfile
       dockerhub_repo: codexstorage/deluge
       tag_latest: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
+      checkout-fetch-depth: 0
+      checkout-fetch-tags: true
     secrets: inherit

--- a/docker/deluge.Dockerfile
+++ b/docker/deluge.Dockerfile
@@ -28,9 +28,15 @@ RUN conda create -y -n 'deluge' python=3.8
 RUN conda init bash
 RUN echo "conda activate deluge" > ~/.bashrc
 
-RUN conda install -y anaconda::py-boost\
-    anaconda::gxx_linux-64\
-    anaconda:openssl
+RUN if [ $(uname -m) = "aarch64" ]; then \
+      conda install -y anaconda::py-boost \
+        anaconda::gxx_linux-aarch64 \
+        anaconda:openssl; \
+    else \
+      conda install -y anaconda::py-boost \
+        anaconda::gxx_linux-64 \
+        anaconda:openssl; \
+    fi
 
 COPY . ./
 


### PR DESCRIPTION
After PR #1, we've observed that builds on arm64 fail.

It was required to adjust Dockerfile for arm64 platform and also, update reusable workflow (https://github.com/codex-storage/github-actions/pull/4) and local workflow as well.